### PR TITLE
Update ospec to ignore hidden directories

### DIFF
--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -16,6 +16,7 @@ function traverseDirectory(pathname, callback) {
 					var promises = []
 					for (var i = 0; i < pathnames.length; i++) {
 						if (pathnames[i] === "node_modules") continue
+						if (pathnames[i][0] === ".") continue
 						pathnames[i] = path.join(pathname, pathnames[i])
 						promises.push(traverseDirectory(pathnames[i], callback))
 					}


### PR DESCRIPTION
Motivation: When using ospec on Cloud9, a difficult-to-diagnose error shows up with "SyntaxError: Unexpected token :"  because ospec is trying to parse metadata about the tests files (like undo information) that is stored under .c9/metadata with the exact same file path and names as the edited files have (e.g. workspace/tests/hello.js).